### PR TITLE
Fix model loading

### DIFF
--- a/textgenrnn/textgenrnn.py
+++ b/textgenrnn/textgenrnn.py
@@ -220,7 +220,7 @@ class textgenrnn:
         self.model.save_weights(weights_path)
 
     def load(self, weights_path):
-        self.model = textgenrnn_model(weights_path, self.num_classes)
+        self.model = textgenrnn_model(self.num_classes, cfg=self.config, weights_path=weights_path)
 
     def reset(self):
         self.config = self.default_config.copy()


### PR DESCRIPTION
After a bit of training, I tried to save the weights to a `hdf5` file, then loading them, but kept getting this error:

> Traceback (most recent call last):
>   File "<stdin>", line 1, in <module>
>   File ".../textgenrnn/textgenrnn.py", line 223, in load
>     self.model = textgenrnn_model(weights_path, self.num_classes)
>   File ".../textgenrnn/textgenrnn/model.py", line 17, in textgenrnn_model
>     input = Input(shape=(cfg['max_length'],), name='input')
> TypeError: 'int' object is not subscriptable

The submitted patch made it work for me.