### PR TITLE
Allow using a backend other than TensorFlow

### DIFF
--- a/textgenrnn/AttentionWeightedAverage.py
+++ b/textgenrnn/AttentionWeightedAverage.py
@@ -1,7 +1,6 @@
 from keras.engine import InputSpec, Layer
 from keras import backend as K
 from keras import initializers
-import tensorflow as tf
 
 
 class AttentionWeightedAverage(Layer):

--- a/textgenrnn/model.py
+++ b/textgenrnn/model.py
@@ -1,6 +1,6 @@
 from keras.optimizers import RMSprop
 from keras.layers import Input, Embedding, Dense, LSTM, Bidirectional
-from keras.layers import CuDNNLSTM, concatenate, Reshape, SpatialDropout1D
+from keras.layers import concatenate, Reshape, SpatialDropout1D
 from keras.models import Model
 from keras import backend as K
 from .AttentionWeightedAverage import AttentionWeightedAverage
@@ -70,6 +70,7 @@ https://github.com/keras-team/keras/issues/8860
 def new_rnn(cfg, layer_num):
     has_gpu = K.backend() == 'tensorflow' and len(K.tensorflow_backend._get_available_gpus()) > 0
     if has_gpu:
+        from keras.layers import CuDNNLSTM
         if cfg['rnn_bidirectional']:
             return Bidirectional(CuDNNLSTM(cfg['rnn_size'],
                                            return_sequences=True),

--- a/textgenrnn/model.py
+++ b/textgenrnn/model.py
@@ -68,7 +68,7 @@ https://github.com/keras-team/keras/issues/8860
 
 
 def new_rnn(cfg, layer_num):
-    has_gpu = len(K.tensorflow_backend._get_available_gpus()) > 0
+    has_gpu = K.backend() == 'tensorflow' and len(K.tensorflow_backend._get_available_gpus()) > 0
     if has_gpu:
         if cfg['rnn_bidirectional']:
             return Bidirectional(CuDNNLSTM(cfg['rnn_size'],

--- a/textgenrnn/model.py
+++ b/textgenrnn/model.py
@@ -68,8 +68,8 @@ https://github.com/keras-team/keras/issues/8860
 
 
 def new_rnn(cfg, layer_num):
-    has_gpu = K.backend() == 'tensorflow' and len(K.tensorflow_backend._get_available_gpus()) > 0
-    if has_gpu:
+    use_cudnnlstm = K.backend() == 'tensorflow' and len(K.tensorflow_backend._get_available_gpus()) > 0
+    if use_cudnnlstm:
         from keras.layers import CuDNNLSTM
         if cfg['rnn_bidirectional']:
             return Bidirectional(CuDNNLSTM(cfg['rnn_size'],

--- a/textgenrnn/utils.py
+++ b/textgenrnn/utils.py
@@ -56,8 +56,8 @@ def textgenrnn_generate(model, vocab,
     if not isinstance(temperature, list):
         temperature = [temperature]
 
-    if model_input_count(model) > 1:
-        model = Model(inputs=model.input[0], outputs=model.output[1])
+    if len(model.inputs) > 1:
+        model = Model(inputs=model.inputs[0], outputs=model.outputs[1])
 
     while next_char != meta_token and len(text) < max_gen_length:
         encoded_text = textgenrnn_encode_sequence(text[-maxlen:],
@@ -155,13 +155,6 @@ def textgenrnn_encode_cat(chars, vocab):
     return a
 
 
-def model_input_count(model):
-    if isinstance(model.input, list):
-        return len(model.input)
-    else:   # is a Tensor
-        return model.input.shape[0]
-
-
 class generate_after_epoch(Callback):
     def __init__(self, textgenrnn, gen_epochs, max_gen_length):
         self.textgenrnn = textgenrnn
@@ -179,7 +172,7 @@ class save_model_weights(Callback):
         self.weights_name = weights_name
 
     def on_epoch_end(self, epoch, logs={}):
-        if model_input_count(self.model) > 1:
-            self.model = Model(inputs=self.model.input[0],
-                               outputs=self.model.output[1])
+        if len(self.model.inputs) > 1:
+            self.model = Model(inputs=self.model.inputs[0],
+                               outputs=self.model.outputs[1])
         self.model.save_weights("{}_weights.hdf5".format(self.weights_name))


### PR DESCRIPTION
I've tried running `textgenrnn` with the PlaidML Keras backend on my Radeon GPU, and ran into some issues: hangups and extreme memory usage (way over 10GiB with the default generator).

Apart from the obvious/trivial ones, the main problem was the way model inputs and outputs were accessed.

The included patches made everything* work nicely for me, using PlaidML on Fedora 28, with the `amdgpu-pro` driver (and the legacy "Orca" OpenCL stack), on my RX580.

Performance wasn't exactly ideal, but that's up to PlaidML, the driver, and who knows what else... (Having/using an OpenCL equivalent of CuDNN would be nice I guess, but that can wait.)

*: I haven't actually tested anything with contexts but I don't think I broke it.