### PR TITLE
Fixes an IndexError exception while in interactive mode.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ allowing it to learn faster and produce better results in some cases.
 setup(
     name='textgenrnn',
     packages=['textgenrnn'],  # this must be the same as the name above
-    version='1.4',
+    version='1.4.1',
     description='Easily train your own text-generating neural network ' \
     'of any size and complexity',
     long_description=long_description,

--- a/textgenrnn/utils.py
+++ b/textgenrnn/utils.py
@@ -129,6 +129,8 @@ def textgenrnn_generate(model, vocab,
                         pass
                 else:
                     print('That\'s not an option!')
+            except IndexError:
+                print('That\'s not an option!')
 
     # if single text, ignore sequences generated w/ padding
     # if not single text, strip the <s> meta_tokens


### PR DESCRIPTION
In interactive mode if you select a number outside one of the options, 100 for example,
you'll receive an IndexError exception since since the input is outside of the array index.