### PR TITLE
Spaces for word-level training should be applied regardless of new_mo…

### DIFF
--- a/textgenrnn/textgenrnn.py
+++ b/textgenrnn/textgenrnn.py
@@ -132,6 +132,12 @@ class textgenrnn:
             train_size = prop_keep
 
         if self.config['word_level']:
+            # If training word level, must add spaces around each
+            # punctuation. https://stackoverflow.com/a/3645946/9314418
+            punct = '!"#$%&()*+,-./:;<=>?@[\]^_`{|}~\\n\\t\'‘’“”’–—…'
+            for i in range(len(texts)):
+                texts[i] = re.sub('([{}])'.format(punct), r' \1 ', texts[i])
+                texts[i] = re.sub(' {2,}', ' ', texts[i])
             texts = [text_to_word_sequence(text, filters='') for text in texts]
 
         # calculate all combinations of text indices + token indices
@@ -237,15 +243,6 @@ class textgenrnn:
             self.config['rnn_layers'], self.config['rnn_size'],
             'Bidirectional ' if self.config['rnn_bidirectional'] else ''
         ))
-
-        # If training word level, must add spaces around each punctuation.
-        # https://stackoverflow.com/a/3645946/9314418
-
-        if self.config['word_level']:
-            punct = '!"#$%&()*+,-./:;<=>?@[\]^_`{|}~\\n\\t\'‘’“”’–—'
-            for i in range(len(texts)):
-                texts[i] = re.sub('([{}])'.format(punct), r' \1 ', texts[i])
-                texts[i] = re.sub(' {2,}', ' ', texts[i])
 
         # Create text vocabulary for new texts
         self.tokenizer = Tokenizer(filters='',


### PR DESCRIPTION
…del, missing the ellipsis in the list of punctuations.

Currently, when attempting to resume training by setting new_model = False, the text is tokenized differently, and incorrectly, vs. the correct tokenization that only happens with new_model = True. This patch moves the punctuation symbol handling to be consistent in both cases.

The list of punctuation is also missing the horizontal ellipsis symbol (U+2026), that is frequently encountered, and by Unicode standard, is the the correctly used character.