### PR TITLE
Fix IndexError when processing missed records

### DIFF
--- a/textgenrnn/utils.py
+++ b/textgenrnn/utils.py
@@ -190,7 +190,8 @@ def textgenrnn_texts_from_file(file_path, header=True,
             texts = []
             reader = csv.reader(f)
             for row in reader:
-                texts.append(row[0])
+                if row:
+                    texts.append(row[0])
         else:
             texts = [line.rstrip(delim) for line in f]
 
@@ -209,8 +210,9 @@ def textgenrnn_texts_from_file_context(file_path, header=True):
         context_labels = []
         reader = csv.reader(f)
         for row in reader:
-            texts.append(row[0])
-            context_labels.append(row[1])
+            if row:
+                texts.append(row[0])
+                context_labels.append(row[1])
 
     return (texts, context_labels)
 


### PR DESCRIPTION
Some valid csv files contain empty rows and break the flow. This easy fix deals with the problem.