### PR TITLE
Identity is not the same thing as equality in Python

### DIFF
--- a/textgenrnn/model.py
+++ b/textgenrnn/model.py
@@ -25,7 +25,7 @@ def textgenrnn_model(num_classes, cfg, context_size=None,
 
     rnn_layer_list = []
     for i in range(cfg['rnn_layers']):
-        prev_layer = embedded if i is 0 else rnn_layer_list[-1]
+        prev_layer = embedded if i == 0 else rnn_layer_list[-1]
         rnn_layer_list.append(new_rnn(cfg, i+1)(prev_layer))
 
     seq_concat = concatenate([embedded] + rnn_layer_list, name='rnn_concat')


### PR DESCRIPTION
We really want equality here.

$ __python__
```python
>>> hi = 'h'
>>> hi += 'i'
>>> hi
'hi'
>>> hi == 'hi'
True
>>> hi is 'hi'
False
>>> 0 == 0.0
True
>>> 0 is 0.0
False
```