### PR TITLE
Fix prefix splitting by every whitespace

### DIFF
--- a/textgenrnn/utils.py
+++ b/textgenrnn/utils.py
@@ -64,7 +64,8 @@ def textgenrnn_generate(model, vocab,
     if word_level and prefix:
         punct = '!"#$%&()*+,-./:;<=>?@[\]^_`{|}~\\n\\t\'‘’“”’–—'
         prefix = re.sub('([{}])'.format(punct), r' \1 ', prefix)
-        prefix_t = [x.lower() for x in prefix.split()]
+        prefix = re.sub(' {2,}', r' ', prefix)
+        prefix_t = [x.lower() for x in prefix.split(' ')]
 
     if not word_level and prefix:
         prefix_t = list(prefix)


### PR DESCRIPTION
Fix process of splitting prefix from splitting by every whitespace into by space only because splitting by every whitespace will remove the newline character and tab character which may be included in the vocabulary.