### PR TITLE
allow save_epochs=0 to never save model weights while training

### DIFF
--- a/textgenrnn/utils.py
+++ b/textgenrnn/utils.py
@@ -297,7 +297,9 @@ class save_model_weights(Callback):
         if len(self.textgenrnn.model.inputs) > 1:
             self.textgenrnn.model = Model(inputs=self.model.input[0],
                                           outputs=self.model.output[1])
-        if self.save_epochs > 0 and (epoch+1) % self.save_epochs == 0 and self.num_epochs != (epoch+1):
+        if self.save_epochs <= 0:
+            return
+        elif (epoch+1) % self.save_epochs == 0 and self.num_epochs != (epoch+1):
             print("Saving Model Weights — Epoch #{}".format(epoch+1))
             self.textgenrnn.model.save_weights(
                 "{}_weights_epoch_{}.hdf5".format(self.weights_name, epoch+1))

--- a/textgenrnn/utils.py
+++ b/textgenrnn/utils.py
@@ -299,7 +299,9 @@ class save_model_weights(Callback):
         if len(self.textgenrnn.model.inputs) > 1:
             self.textgenrnn.model = Model(inputs=self.model.input[0],
                                           outputs=self.model.output[1])
-        if self.save_epochs > 0 and (epoch+1) % self.save_epochs == 0 and self.num_epochs != (epoch+1):
+        if self.save_epochs <= 0:
+            return
+        elif (epoch+1) % self.save_epochs == 0 and self.num_epochs != (epoch+1):
             print("Saving Model Weights — Epoch #{}".format(epoch+1))
             self.textgenrnn.model.save_weights(
                 "{}_weights_epoch_{}.hdf5".format(self.weights_name, epoch+1))


### PR DESCRIPTION
I have a use case where I _only_ want to save the model weights at the end of the training. This PR adds a check for save_epochs<=0 in the `on_epoch_end` callback to allow disabling all weights saving while training.

EDIT: sorry for the extra commits; did a rebase to master.