### PR TITLE
Fix override get_config warning

### DIFF
--- a/textgenrnn/AttentionWeightedAverage.py
+++ b/textgenrnn/AttentionWeightedAverage.py
@@ -62,3 +62,8 @@ class AttentionWeightedAverage(Layer):
             return [None] * len(input_mask)
         else:
             return None
+
+    def get_config(self):
+        config = super(AttentionWeightedAverage, self).get_config()
+        config.update({"return_attention": self.return_attention})
+        return config


### PR DESCRIPTION
Fixes ```WARNING:tensorflow:Model failed to serialize as JSON. Ignoring... Layer AttentionWeightedAverage has arguments in `__init__` and therefore must override `get_config`.```

Superfluous but gets rid of a warning, from what I understand it shouldn't affect functionality in any way.